### PR TITLE
Allows DV7toDV8.sh script to work on non-Mac hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,49 @@ Dolby Vision profile 7 to Dolby Vision profile 8.1 conversion utility for macOS
 
 # Script Usage
 
-If you prefer to use a plaintext Bash script over an app, you can also run `DV7toDV8.sh` directly.
+The `DV7toDV8.sh` script offers a more transparent but less streamlined approach compared to the app. It provides additional options for customization:
 
-The upside is that you can see and read exactly what you're running; the downside is that macOS doesn't want you to run downloaded tools, so you'll have to approve each utility in the System Settings app.
+```bash
+./DV7toDV8.sh [options]
+```
 
+## Options
+
+### -k or --keep-files
+
+Keeps intermediate files generated during the conversion process.
+
+### -t or --target
+
+Specifies the target directory where .mkv files are located. Defaults to the current directory if not specified.
+
+### -l
+
+Specifies comma-separated language codes for audio and subtitle tracks to include in the final .mkv file. If not specified, all tracks are included.
+
+### -u or --use-local
+
+Uses local system binaries of `mkvtoolnix` and `dovi_tool` if available, instead of the versions bundled with the script.
+
+### -h or --help
+
+Displays the help message detailing all options.
+
+## Example
+  
+```bash
+./DV7toDV8.sh -k -t /path/to/mkv/files -l eng,spa
+```
+
+### MacOS
 - Download and extract the repo
 - Run `DV7toDV8.sh` in Terminal, passing one argument for the folder location of the MKV files you want to convert
 - On first run of each utility, you'll need to approve the app to run and then re-run the script
-- The bundled tools are unmodified versions of those publicly available, so if you're uncomfortable running the utilities downloaded in the `tools` folder, you can download and use your own copies of `dovi_tool` and `mkvtoolnix` (both can be installed via Homebrew); you'll just need to update the paths to the tools appropriately in the script
+- The bundled tools are unmodified versions of those publicly available, so if you're uncomfortable running the utilities downloaded in the `tools` folder, you can download and use your own copies of `dovi_tool` and `mkvtoolnix` (both can be installed via Homebrew)
+  - If you choose to use your own copies of the utilities, you can pass the `-u` or `--use-local` flag to the script to use the local versions
+  - If you install the tools using Homebrew, they will be added to your PATH and the script will automatically use them
+  - If you install the tools manually, you will need to add the directory containing the tools to your PATH
+  - Finally, you can alternatively update DV7toDV8.sh to point to the location of the tools on your system
 - To approve the tools to run, you can run each tool in the `tools` folder in Terminal, or just run the script repeatedly (passing a folder containing MKV files as an argument)
   - Run the script once
   - Open the **System Settings** app
@@ -58,6 +93,12 @@ The upside is that you can see and read exactly what you're running; the downsid
   - Run the script a third time
   - Approve the `mkvmerge` utility to run
 - All utilities should now be approved and the script can be run normally
+
+## Linux
+- The steps for running the script on Linux are similar to those for macOS with a few exceptions
+  - The script will not prompt you to enter language codes. These can be specified using the `-l` flag or ommitted to include all tracks
+  - The script will not prompt you to approve the tools to run. As long as the tools are executable, they should run without issue
+
 
 # Building
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Dolby Vision profile 7 to Dolby Vision profile 8.1 conversion utility for macOS
 - The app will process each `.mkv` file in the folder, performing the following:
   - Demux the DV7 BL+EL+RPU HEVC video stream from the MKV container
   - Demux the DV7 EL+RPU enhancement layer from the HEVC stream for your archival purposes (delete this file if you don't care to be able to reconstruct the DV7 BL+EL+RPU in the future)
-  - Convert the DV7 BL+EL+RPU to DV8 BL+RPU, removing tone mappings specific to profile 7 and any CM v4.0 mappings (leaving CM v2.9)
+  - Convert the DV7 BL+EL+RPU to DV8 BL+RPU, removing tone mappings specific to profile 7
   - Delete the DV7 BL+EL+RPU HEVC file to conserve disk space
   - Extract the DV8 RPU from the DV8 BL+RPU HEVC stream
   - Plot a graph of the L1 metadata and render it into a PNG

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Keeps intermediate files generated during the conversion process.
 
 Specifies the target directory where .mkv files are located. Defaults to the current directory if not specified.
 
-### -l
+### `-l` or `--languages`
 
-Specifies comma-separated language codes for audio and subtitle tracks to include in the final .mkv file. If not specified, all tracks are included.
+Specifies comma-separated language codes for audio and subtitle tracks to include in the final `.mkv` file. You can provide [ISO 639-1 codes (`en,es,de`) or ISO 639-2 codes (`eng,spa,ger`)](https://www.loc.gov/standards/iso639-2/php/English_list.php). If not specified, all tracks are included.
 
 ### `-u` or `--use-local`
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ The `DV7toDV8.sh` script offers a more transparent but less streamlined approach
 
 ## Options
 
-### -k or --keep-files
+### `-k` or `--keep-files`
 
 Keeps intermediate files generated during the conversion process.
 
-### -t or --target
+### `-t` or `--target`
 
 Specifies the target directory where .mkv files are located. Defaults to the current directory if not specified.
 
@@ -59,11 +59,11 @@ Specifies the target directory where .mkv files are located. Defaults to the cur
 
 Specifies comma-separated language codes for audio and subtitle tracks to include in the final .mkv file. If not specified, all tracks are included.
 
-### -u or --use-local
+### `-u` or `--use-local`
 
 Uses local system binaries of `mkvtoolnix` and `dovi_tool` if available, instead of the versions bundled with the script.
 
-### -h or --help
+### `-h` or `--help`
 
 Displays the help message detailing all options.
 
@@ -73,7 +73,7 @@ Displays the help message detailing all options.
 ./DV7toDV8.sh -k -t /path/to/mkv/files -l eng,spa
 ```
 
-### MacOS
+### macOS
 - Download and extract the repo
 - Run `DV7toDV8.sh` in Terminal, passing one argument for the folder location of the MKV files you want to convert
 - On first run of each utility, you'll need to approve the app to run and then re-run the script
@@ -81,7 +81,7 @@ Displays the help message detailing all options.
   - If you choose to use your own copies of the utilities, you can pass the `-u` or `--use-local` flag to the script to use the local versions
   - If you install the tools using Homebrew, they will be added to your PATH and the script will automatically use them
   - If you install the tools manually, you will need to add the directory containing the tools to your PATH
-  - Finally, you can alternatively update DV7toDV8.sh to point to the location of the tools on your system
+  - Finally, you can alternatively update `DV7toDV8.sh` to point to the location of the tools on your system
 - To approve the tools to run, you can run each tool in the `tools` folder in Terminal, or just run the script repeatedly (passing a folder containing MKV files as an argument)
   - Run the script once
   - Open the **System Settings** app

--- a/src/DV7toDV8.sh
+++ b/src/DV7toDV8.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Mac specific
+# Mac-specific tests for local tools
 # Only needed when relying on a local install of mkvtoolnix
 # which mkvmerge >/dev/null
 # if [[ $? == 1 ]]
@@ -32,7 +32,7 @@ function print_help {
     echo "Options:"
     echo "-k|--keep-files       Keep working files"
     echo "-t|--target PATH      Specify the target directory (default: current directory)"
-    echo "-l|languages LANG     Specify the language codes (comma-separated) for audio and subtitle tracks. If not specified, default to all tracks."
+    echo "-l|--languages LANGS  Specify comma-separated ISO 639-1 (en,es,de) or ISO 639-2 language codes (eng,spa,ger) for audio and subtitle tracks to keep (default: keep all tracks)"
     echo "-u|--use-local        Use local system binaries if available"
     echo "-h|--help             Display this help message"
     echo ""
@@ -100,7 +100,7 @@ else
     mkvmergePath=$toolsPath/mkvmerge
 fi
 jsonFilePath=$configPath/DV7toDV8.json
-# If we're running on a mac and the language code(s) are not provided, get them from the user
+# If we're running on a Mac and the language code(s) are not provided, get them from the user
 if [[ $(uname) == "Darwin" ]] && [[ $languageCodeSet == false ]]
 then
     echo "Getting language codes..."

--- a/src/DV7toDV8.sh
+++ b/src/DV7toDV8.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# Mac specific
 # Only needed when relying on a local install of mkvtoolnix
 # which mkvmerge >/dev/null
 # if [[ $? == 1 ]]

--- a/src/DV7toDV8.sh
+++ b/src/DV7toDV8.sh
@@ -27,7 +27,7 @@ useLocal=false
 
 # Help function
 function print_help {
-    echo "Usage: $0 [options]"
+    echo "Usage: $0 [options] [target directory]"
     echo ""
     echo "Options:"
     echo "-k|--keep-files       Keep working files"
@@ -47,10 +47,6 @@ while (( "$#" )); do
     shift;;
   -h|--help)
     print_help;;
-  -t|--target)
-    targetDir=$2
-    echo "Target directory set to '$targetDir'"
-    shift 2;;
   -l|--languages)
     languageCodes=$2
     echo "Language codes set to '$languageCodes'"
@@ -63,8 +59,8 @@ while (( "$#" )); do
   -*|--*=) # unsupported flags
     echo "Error: Unsupported flag $1" >&2
     exit 1;;
-  *) # preserve positional arguments
-    PARAMS="$PARAMS $1"
+  *)
+    targetDir=$1
     shift;;
   esac
 done

--- a/src/DV7toDV8.sh
+++ b/src/DV7toDV8.sh
@@ -91,7 +91,7 @@ languageCodesPath=$toolsPath/language_codes.applescript
 # If the --use-local flag is set, use the executables on the user's system; otherwise, use the executables in the tools directory
 if [[ $useLocal == true ]]
 then
-    doviToolPath=dov_tool
+    doviToolPath=dovi_tool
     mkvextractPath=mkvextract
     mkvmergePath=mkvmerge
 else

--- a/src/DV7toDV8.sh
+++ b/src/DV7toDV8.sh
@@ -32,7 +32,7 @@ function print_help {
     echo "Options:"
     echo "-k|--keep-files       Keep working files"
     echo "-t|--target PATH      Specify the target directory (default: current directory)"
-    echo "-l LANG               Specify the language codes (comma-separated) for audio and subtitle tracks. If not specified, default to all tracks."
+    echo "-l|languages LANG     Specify the language codes (comma-separated) for audio and subtitle tracks. If not specified, default to all tracks."
     echo "-u|--use-local        Use local system binaries if available"
     echo "-h|--help             Display this help message"
     echo ""
@@ -51,7 +51,7 @@ while (( "$#" )); do
     targetDir=$2
     echo "Target directory set to '$targetDir'"
     shift 2;;
-  -l)
+  -l|--languages)
     languageCodes=$2
     echo "Language codes set to '$languageCodes'"
     languageCodeSet=true


### PR DESCRIPTION
This MR allows the script to run on non-mac hardware. 

My home media server runs on Linux and I do most of my work there, so being able to run this on Linux seemed like it would also be helpful for other users.

This MR:
- Adds support for additional command line arguments
- Updates the README to reflect those arguments
- Slightly rewords some things in the README
- Only prompts the user for language codes via applescript if the user is running on a Mac and they have not passed in the language codes via command line argument